### PR TITLE
Use MySQL wrapper and batch plant saves

### DIFF
--- a/server/startup.lua
+++ b/server/startup.lua
@@ -1,47 +1,31 @@
 local _started
 
-local function EnsureWeedPlantsTable(cb)
-	exports.oxmysql:execute([[
-		CREATE TABLE IF NOT EXISTS `weed_plants` (
-			`id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
-			`data` LONGTEXT NOT NULL COLLATE 'utf8mb4_general_ci',
-			PRIMARY KEY (`id`) USING BTREE
-		)
-		COLLATE='utf8mb4_general_ci'
-		ENGINE=InnoDB;
-	]], {}, function()
-		if cb then cb() end
-	end)
-end
-
 function Startup()
 	if _started then return end
 	_started = true
 
-	EnsureWeedPlantsTable(function()
-		exports.oxmysql:query("SELECT id, data FROM weed_plants", {}, function(results)
-			local count = 0
+	MySQL.query("SELECT id, data FROM weed_plants", {}, function(results)
+		local count = 0
 
-			if results and #results > 0 then
-				for _, row in ipairs(results) do
-					local ok, plant = pcall(json.decode, row.data or "{}")
-					if ok and plant and plant.planted then
-						if os.time() - plant.planted <= Config.Lifetime then
-							plant._id = row.id
+		if results and #results > 0 then
+			for _, row in ipairs(results) do
+				local ok, plant = pcall(json.decode, row.data or "{}")
+				if ok and plant and plant.planted then
+					if os.time() - plant.planted <= Config.Lifetime then
+						plant._id = row.id
 
-							_plants[plant._id] = {
-								plant = plant,
-								stage = getStageByPct(plant.growth or 0),
-							}
+						_plants[plant._id] = {
+							plant = plant,
+							stage = getStageByPct(plant.growth or 0),
+						}
 
-							count = count + 1
-						end
+						count = count + 1
 					end
 				end
 			end
+		end
 
-			Logger:Trace("Weed", string.format("Loaded ^2%s^7 Weed Plants", count), { console = true })
-		end)
+		Logger:Trace("Weed", string.format("Loaded ^2%s^7 Weed Plants", count), { console = true })
 	end)
 
 	Reputation:Create("weed", "Weed", {

--- a/server/tasks.lua
+++ b/server/tasks.lua
@@ -13,13 +13,22 @@ function SaveAllPlants()
     end
 
     if #docs > 0 then
-		Logger:Info("Weed", string.format("Saving ^2%s^7 Plants", #docs))
+        Logger:Info("Weed", string.format("Saving ^2%s^7 Plants", #docs))
+        local queries = {}
         for _, plant in ipairs(docs) do
             if plant._id then
-                exports.oxmysql:update(
-                    "UPDATE weed_plants SET data = ? WHERE id = ?", { json.encode(plant), plant._id }
-                )
+                table.insert(queries, {
+                    query = "UPDATE weed_plants SET data = ? WHERE id = ?",
+                    values = {
+                        json.encode(plant),
+                        plant._id
+                    }
+                })
             end
+        end
+
+        if #queries > 0 then
+            MySQL.transaction(queries)
         end
     end
 end

--- a/server/weed.lua
+++ b/server/weed.lua
@@ -101,12 +101,9 @@ WEED = {
             if _plants[id] ~= nil then
                 local plant = _plants[id].plant
                 _plants[id] = nil
-
+				-- plant._id  and id the same??
                 if plant and plant._id then
-                    exports.oxmysql:execute(
-                        "DELETE FROM weed_plants WHERE id = ?",
-                        { plant._id }
-                    )
+                	MySQL.query('DELETE FROM weed_plants WHERE id = ?', {plant._id })
                 end
 
                 TriggerClientEvent("Weed:Client:Objects:Delete", -1, id)
@@ -125,7 +122,7 @@ WEED = {
                 water = 100.0,
             }
 
-			exports.oxmysql:insert(
+			MySQL.insert(
                 "INSERT INTO weed_plants (data) VALUES (?)",
                 { json.encode(weed) },
                 function(insertId)


### PR DESCRIPTION
Replace exports.oxmysql calls with the MySQL wrapper throughout the weed server code. Remove the EnsureWeedPlantsTable helper and load plants via MySQL.query. SaveAllPlants now builds a list of update queries and runs them in a single MySQL.transaction for batched saves. Also switch deletes/inserts to MySQL.query/MySQL.insert and apply minor formatting/whitespace cleanup.

must use the txadminreciper PR 